### PR TITLE
Fix missing imports and logging error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -177,7 +177,7 @@ async def chat(query: dict):
             try:
                 obj = json.loads(line_decoded)
                 sql += obj.get("response", "")
-            except Exception:
+            except Exception as e:
                 logger.warning(f"Failed to parse JSON: {e} | Line: {line_decoded}")
                 continue
 

--- a/app/qif_indexer.py
+++ b/app/qif_indexer.py
@@ -3,7 +3,7 @@ import re
 import pandas as pd
 import logging
 from sqlalchemy import create_engine, Column, Float, String, Date, MetaData, Table
-from datetime import date
+from datetime import date, datetime
 
 class QIFIndexer:
     def __init__(self, qif_dir: str, db_path: str):


### PR DESCRIPTION
## Summary
- import `datetime` for the QIF indexer
- capture exception as `e` when parsing streamed results

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba991a5fc8323b88746a70b15f268