### PR TITLE
Apply sticky positioning to `#qif-topbar` and remove Streamlit testid selector

### DIFF
--- a/ui/qif_chat.py
+++ b/ui/qif_chat.py
@@ -21,13 +21,10 @@ status_text = "Processing" if st.session_state.is_processing else "Ready"
 st.markdown(
     f"""
     <style>
-      div[data-testid="stVerticalBlock"] div:has(> #qif-topbar-anchor) {{
+      #qif-topbar {{
         position: sticky;
         top: 0;
         z-index: 1000;
-      }}
-
-      #qif-topbar {{
         border: 1px solid rgba(49, 51, 63, 0.25);
         background: rgba(255, 255, 255, 0.95);
         color: #111111;
@@ -79,7 +76,6 @@ st.markdown(
     </style>
 
     <a id="page-top"></a>
-    <div id="qif-topbar-anchor"></div>
     <div id="qif-topbar">
       <div id="qif-topbar-content">
         <div><strong>{datetime.now().strftime('%A, %B %d, %Y at %I:%M:%S %p')}</strong></div>


### PR DESCRIPTION
### Motivation
- The topbar floating behavior previously depended on Streamlit internal `data-testid` selectors which is fragile and can break when Streamlit's markup changes. 
- The goal is to make the topbar itself responsible for the sticky behavior so the UI is more robust and self-contained. 
- Keep the visual styling on the same element that provides the sticky behavior to avoid split responsibilities between wrapper and content.

### Description
- Removed the rule that targeted `div[data-testid="stVerticalBlock"] div:has(> #qif-topbar-anchor)` and applied `position: sticky; top: 0; z-index: 1000;` directly to `#qif-topbar` in the inline `<style>` block of `ui/qif_chat.py`.
- Preserved existing visual styling (`border`, `background`, `padding`, `backdrop-filter`, `border-radius`, etc.) on `#qif-topbar` so the same element is both styled and sticky.
- Removed the now-unused `#qif-topbar-anchor` element from the markup and verified there are no remaining selectors relying on `data-testid` for floating behavior.

### Testing
- Ran `python -m py_compile ui/qif_chat.py` and it completed successfully.
- Verified via code search that no `data-testid`-based selector remains in `ui/qif_chat.py` for floating behavior.
- Launched the app with `streamlit run ui/qif_chat.py --server.headless true --server.port 8501` and captured a Playwright screenshot to validate the rendered UI, all steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d07543ae083239f439d0ed3836171)