### PR TITLE
Simplify sticky topbar structure in ui/qif_chat.py

### DIFF
--- a/ui/qif_chat.py
+++ b/ui/qif_chat.py
@@ -21,13 +21,10 @@ status_text = "Processing" if st.session_state.is_processing else "Ready"
 st.markdown(
     f"""
     <style>
-      div[data-testid="stVerticalBlock"] div:has(> #qif-topbar-anchor) {{
+      #qif-topbar {{
         position: sticky;
         top: 0;
         z-index: 1000;
-      }}
-
-      #qif-topbar {{
         border: 1px solid rgba(49, 51, 63, 0.25);
         background: rgba(255, 255, 255, 0.95);
         color: #111111;
@@ -79,7 +76,6 @@ st.markdown(
     </style>
 
     <a id="page-top"></a>
-    <div id="qif-topbar-anchor"></div>
     <div id="qif-topbar">
       <div id="qif-topbar-content">
         <div><strong>{datetime.now().strftime('%A, %B %d, %Y at %I:%M:%S %p')}</strong></div>


### PR DESCRIPTION
### Motivation
- Remove an unnecessary wrapper used only for sticky targeting and make the topbar itself the sticky element while preserving jump navigation and status display.

### Description
- Removed the `<div id="qif-topbar-anchor"></div>` from the Streamlit HTML snippet.
- Moved `position: sticky; top: 0; z-index: 1000;` directly onto `#qif-topbar` so the topbar is the direct sticky element.
- Kept `<a id="page-top"></a>` and preserved the up/down navigation links and the `.qif-status-pill` behavior unchanged.

### Testing
- Successfully compiled the file with `python -m py_compile ui/qif_chat.py`.
- Launched the app with `streamlit run ui/qif_chat.py` and captured a screenshot to confirm the topbar renders and behaves as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d075c2b188323843a28b4baef0361)